### PR TITLE
Implement serialization and deserialization for ISIN

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,14 @@ include = []
 [dev-dependencies]
 proptest = "1.2.0"
 criterion = { version = "0.5.1", features = ["html_reports"] }
+serde_json = "1.0.107"
 
 [dependencies]
+serde = { version = "1.0.188", optional = true }
+
+[features]
+default = []
+serde = ["dep:serde"]
 
 [[bench]]
 name = "checksum_compare"
@@ -24,3 +30,7 @@ harness = false
 [[bench]]
 name = "parse"
 harness = false
+
+[[example]]
+name = "serde"
+required-features = ["serde"]

--- a/examples/serde.rs
+++ b/examples/serde.rs
@@ -1,0 +1,16 @@
+use isin::ISIN;
+
+fn main() {
+    let isin: ISIN = "US0378331005".parse().unwrap();
+
+    let serialized = serde_json::to_string(&isin).unwrap();
+    println!("Serialized ISIN: {}", serialized);
+
+    let deserialized: ISIN = serde_json::from_str(&serialized).unwrap();
+
+    println!("Deserialized ISIN: {}", deserialized.to_string()); // "US0378331005"
+    println!("  Prefix: {}", deserialized.prefix()); // "US"
+    println!("  Basic code: {}", deserialized.basic_code()); // "037833100"
+    println!("  Check digit: {}", deserialized.check_digit()); // '5'
+    assert_eq!(isin, deserialized);
+}


### PR DESCRIPTION
Fixes part of #1.

As noted in the code, there are two issues for discussion:

1. The current code uses `ISIN::value` for serialization, which is marked as deprecated. However, the suggested `ToString::to_string` is not a good replacement, since it necessitates a heap allocation. There are three options for resolution:
   1. Do nothing & keep as is. May run into trouble when removing `ISIN::value` at some point.
   2. Change serialization to construct the `str` slice on the fly, as done in other methods.
   3. Implement `AsRef<str>` for ISIN and advertise that as replacement for `ISIN::value`.
   4. Undeprecate `ISIN::value`
2. Right now, (de)serialization always uses strings. For formats that support it, we could serialize an ISIN as a fixed-length byte array, potentially saving some overhead.