### PR TITLE
Make crate no_std compatible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ categories = ["parsing"]
 readme = "README.md"
 repository = "https://github.com/gnp/isin-rs.git"
 include = []
+rust-version = "1.81"
 
 [dev-dependencies]
 proptest = "1.3.1"
@@ -17,10 +18,11 @@ criterion = { version = "0.5.1", features = ["html_reports"] }
 serde_json = "1.0.107"
 
 [dependencies]
-serde = { version = "1.0.188", optional = true }
+serde = { version = "1.0.188", default-features = false, optional = true }
 
 [features]
-default = []
+default = ["std"]
+std = ["serde?/std"]
 serde = ["dep:serde"]
 
 [[bench]]

--- a/src/checksum.rs
+++ b/src/checksum.rs
@@ -50,25 +50,38 @@ fn char_value(c: &u8) -> u8 {
 /// A direct translation of the formula definition, in the functional style.
 #[allow(dead_code)]
 pub fn checksum_functional(s: &[u8]) -> u8 {
-    fn digits_of(x: u8) -> Vec<u8> {
-        if x >= 10 {
-            vec![x / 10, x % 10]
-        } else {
-            vec![x]
+    struct Digits(Option<u8>, Option<u8>);
+    impl Digits {
+        fn of(x: u8) -> Self {
+            if x >= 10 {
+                Digits(Some(x / 10), Some(x % 10))
+            } else {
+                Digits(Some(x), None)
+            }
         }
     }
-
+    impl Iterator for Digits {
+        type Item = u8;
+        fn next(&mut self) -> Option<Self::Item> {
+            self.0.take().or_else(|| self.1.take())
+        }
+    }
+    impl DoubleEndedIterator for Digits {
+        fn next_back(&mut self) -> Option<Self::Item> {
+            self.1.take().or_else(|| self.0.take())
+        }
+    }
     let sum: u32 = s
         .iter()
         .map(char_value)
-        .flat_map(digits_of)
+        .flat_map(Digits::of)
         .rev()
         .enumerate()
         .flat_map(|(i, x)| {
             if (i % 2) == 0 {
-                digits_of(x * 2)
+                Digits::of(x * 2)
             } else {
-                digits_of(x)
+                Digits::of(x)
             }
         })
         .map(|x| x as u32)
@@ -167,6 +180,7 @@ pub fn checksum_table(s: &[u8]) -> u8 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::string::ToString;
     use proptest::prelude::*;
 
     // Ensure the table-driven method gets the same answer as the functional style implementation

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,8 +3,8 @@
 //!
 //! Error type for ISIN parsing and building.
 
-use std::fmt::Formatter;
-use std::fmt::{Debug, Display};
+use core::fmt::Formatter;
+use core::fmt::{Debug, Display};
 
 /// All the ways parsing or building could fail.
 #[non_exhaustive]
@@ -75,7 +75,7 @@ pub enum Error {
 }
 
 impl Debug for Error {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         match self {
             Error::InvalidValueStringLength { was } => {
                 write!(f, "InvalidValueStringLength {{ was: {was:?} }}")
@@ -101,7 +101,7 @@ impl Debug for Error {
             Error::InvalidBasicCodeArrayLength { was } => {
                 write!(f, "InvalidBasicCodeArrayLength {{ was: {was:?} }}")
             }
-            Error::InvalidPrefix { was } => match std::str::from_utf8(was) {
+            Error::InvalidPrefix { was } => match core::str::from_utf8(was) {
                 Ok(s) => {
                     write!(f, "InvalidPrefix {{ was: {s:?} }}")
                 }
@@ -109,7 +109,7 @@ impl Debug for Error {
                     write!(f, "InvalidPrefix {{ was: (invalid UTF-8) {was:?} }}")
                 }
             },
-            Error::InvalidBasicCode { was } => match std::str::from_utf8(was) {
+            Error::InvalidBasicCode { was } => match core::str::from_utf8(was) {
                 Ok(s) => {
                     write!(f, "InvalidBasicCode {{ was: {s:?} }}")
                 }
@@ -133,7 +133,7 @@ impl Debug for Error {
 }
 
 impl Display for Error {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         match self {
             Error::InvalidValueStringLength { was } => {
                 write!(
@@ -183,7 +183,7 @@ impl Display for Error {
                     "invalid Basic Code array length {was} bytes when expecting 9"
                 )
             }
-            Error::InvalidPrefix { was } => match std::str::from_utf8(was) {
+            Error::InvalidPrefix { was } => match core::str::from_utf8(was) {
                 Ok(s) => {
                     write!(
                         f,
@@ -196,7 +196,7 @@ impl Display for Error {
                     )
                 }
             },
-            Error::InvalidBasicCode { was } => match std::str::from_utf8(was) {
+            Error::InvalidBasicCode { was } => match core::str::from_utf8(was) {
                 Ok(s) => {
                     write!(
                         f,
@@ -228,7 +228,7 @@ impl Display for Error {
     }
 }
 
-impl std::error::Error for Error {}
+impl core::error::Error for Error {}
 
 #[cfg(test)]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![no_std]
 #![warn(missing_docs)]
 //! # isin
 //!
@@ -32,9 +33,13 @@
 //! * [LEI](https://crates.io/crates/lei): Legal Entity Identifier (ISO 17442:2020)
 //!
 
-use std::fmt;
-use std::str::from_utf8_unchecked;
-use std::str::FromStr;
+#[cfg(test)]
+#[macro_use]
+extern crate std;
+
+use core::fmt;
+use core::str::from_utf8_unchecked;
+use core::str::FromStr;
 
 pub mod checksum;
 
@@ -115,9 +120,17 @@ pub fn parse(value: &str) -> Result<ISIN, Error> {
 /// or trailing whitespace and/or lowercase letters as long as it is otherwise the right length
 /// and format.
 pub fn parse_loose(value: &str) -> Result<ISIN, Error> {
-    let uc = value.to_ascii_uppercase();
-    let temp = uc.trim();
-    parse(temp)
+    let value = value.trim();
+    if value.len() != 12 {
+        return Err(Error::InvalidValueStringLength { was: value.len() });
+    }
+
+    let mut bb = [0u8; 12];
+    bb.copy_from_slice(value.as_bytes());
+    bb.make_ascii_uppercase();
+
+    let value = unsafe { from_utf8_unchecked(&bb) };
+    parse(value)
 }
 
 /// Build an ISIN from a _Payload_ (an already-concatenated _Prefix_ and _Basic Code_). The
@@ -322,6 +335,7 @@ impl ISIN {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::string::ToString;
     use proptest::prelude::*;
 
     #[test]
@@ -531,6 +545,7 @@ mod tests {
         fn deserialize_apple() {
             let isin = ISIN::deserialize(StrDeserializer::<value::Error>::new("US0378331005"))
                 .expect("successful deserialization");
+            use std::string::ToString;
             assert_eq!(isin.to_string(), "US0378331005");
             assert_eq!(isin.prefix(), "US");
             assert_eq!(isin.basic_code(), "037833100");


### PR DESCRIPTION
This PR makes this crate `no_std` compatible.

Unfortunately, this comes with a breaking change - the msrv is bumped from 1.60 to 1.81, because of `core::error::Error`.
In case this is not acceptable, this can be mitigated either by adding a `std` feature and only implementing `std::error::Error` when the feature enabled or by using the approach similar to what is used in `anyhow` crate [^1] [^2].

[^1]: https://github.com/dtolnay/anyhow/blob/master/build.rs#L73
[^2]: https://github.com/dtolnay/anyhow/blob/master/src/lib.rs#L276-L280
